### PR TITLE
Add invoice listing APIs and serverless config

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,39 @@
+service: hubspot-invoicing
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  region: us-east-1
+  environment:
+    S3_REPORTS_BUCKET_NAME: ${env:S3_REPORTS_BUCKET_NAME}
+    AWS_REGION: ${env:AWS_REGION}
+
+functions:
+  listInvoices:
+    handler: src/api/listInvoices.handler
+    events:
+      - http:
+          path: invoices
+          method: get
+          cors: true
+
+  getInvoice:
+    handler: src/api/getInvoice.handler
+    events:
+      - http:
+          path: invoice/{key}
+          method: get
+          cors: true
+          request:
+            parameters:
+              paths:
+                key: true
+
+  triggerGeneration:
+    handler: src/api/triggerGeneration.handler
+    events:
+      - http:
+          path: invoices/generate
+          method: post
+          cors: true

--- a/src/api/getInvoice.js
+++ b/src/api/getInvoice.js
@@ -1,0 +1,35 @@
+const AWS = require('aws-sdk');
+const config = require('../config');
+const logger = require('../utils/logger');
+
+const s3 = new AWS.S3({ region: config.AWS_REGION || 'us-east-1' });
+
+/**
+ * Lambda handler to generate a pre-signed URL for an invoice PDF in S3.
+ */
+exports.handler = async (event) => {
+  const bucketName = config.S3_REPORTS_BUCKET_NAME;
+  if (!bucketName) {
+    logger.error('S3_REPORTS_BUCKET_NAME is not configured.');
+    return { statusCode: 500, body: 'S3 bucket not configured.' };
+  }
+
+  const key = event.pathParameters?.key || event.queryStringParameters?.key;
+  if (!key) {
+    return { statusCode: 400, body: 'Missing invoice key.' };
+  }
+
+  const expires = parseInt(event.queryStringParameters?.expires, 10) || 900;
+
+  try {
+    const url = await s3.getSignedUrlPromise('getObject', {
+      Bucket: bucketName,
+      Key: key,
+      Expires: expires,
+    });
+    return { statusCode: 200, body: JSON.stringify({ url }) };
+  } catch (err) {
+    logger.error('Failed to create signed URL', err);
+    return { statusCode: 500, body: 'Error generating URL.' };
+  }
+};

--- a/src/api/listInvoices.js
+++ b/src/api/listInvoices.js
@@ -1,0 +1,44 @@
+const AWS = require('aws-sdk');
+const config = require('../config');
+const logger = require('../utils/logger');
+
+const s3 = new AWS.S3({ region: config.AWS_REGION || 'us-east-1' });
+
+/**
+ * Lambda handler to list invoice objects stored in S3.
+ * Returns an array of keys and their metadata.
+ */
+exports.handler = async (event) => {
+  const bucketName = config.S3_REPORTS_BUCKET_NAME;
+  if (!bucketName) {
+    logger.error('S3_REPORTS_BUCKET_NAME is not configured.');
+    return { statusCode: 500, body: 'S3 bucket not configured.' };
+  }
+
+  const prefix = event.queryStringParameters?.prefix || '';
+
+  try {
+    const listParams = { Bucket: bucketName, Prefix: prefix };
+    const listed = await s3.listObjectsV2(listParams).promise();
+    const results = [];
+
+    for (const obj of listed.Contents || []) {
+      let metadata = {};
+      try {
+        const head = await s3.headObject({ Bucket: bucketName, Key: obj.Key }).promise();
+        metadata = head.Metadata;
+      } catch (err) {
+        logger.warn(`Failed to fetch metadata for ${obj.Key}`, err);
+      }
+      results.push({ key: obj.Key, metadata });
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(results),
+    };
+  } catch (err) {
+    logger.error('Failed to list invoices from S3', err);
+    return { statusCode: 500, body: 'Error listing invoices.' };
+  }
+};

--- a/src/api/triggerGeneration.js
+++ b/src/api/triggerGeneration.js
@@ -1,0 +1,29 @@
+const processor = require('../index');
+const logger = require('../utils/logger');
+
+/**
+ * Lambda handler that triggers the invoice generation process.
+ * Accepts options via HTTP request body and forwards them to the main handler.
+ */
+exports.handler = async (event, context) => {
+  let options = {};
+  try {
+    if (event.body) {
+      options = JSON.parse(event.body);
+    }
+  } catch (err) {
+    logger.warn('Failed to parse request body', err);
+    return { statusCode: 400, body: 'Invalid JSON body.' };
+  }
+
+  try {
+    const result = await processor.handler(options, context);
+    return {
+      statusCode: 200,
+      body: JSON.stringify(result),
+    };
+  } catch (err) {
+    logger.error('Invoice generation failed', err);
+    return { statusCode: 500, body: 'Error triggering generation.' };
+  }
+};


### PR DESCRIPTION
## Summary
- add Lambda functions to list invoices, retrieve an invoice URL, and trigger invoice generation
- provide Serverless Framework configuration for API Gateway endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68604673361c83279b72d2cae7fd845a