### PR TITLE
Add React UI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,29 @@ The Lambda function will require configuration for:
 -   SES email addresses for notifications and reports
 
 (Further details to be added.)
+## React UI
+
+A lightweight React single-page application is located in the `ui/` directory. It provides two pages:
+
+- **Invoice List** – displays invoices retrieved from `/invoices` and provides links to view or download each invoice.
+- **Generate** – form interface to trigger the `/generate` endpoint with options for run type, limits and optional IDs.
+
+### Building and Deploying
+
+```bash
+cd ui
+npm install
+npm run build
+```
+
+Set the `S3_BUCKET` environment variable to your destination bucket and run:
+
+```bash
+npm run deploy
+```
+
+This syncs the `ui/dist` directory to the specified S3 bucket. If you use CloudFront, create an invalidation after syncing.
+
+### Environment Variables
+
+The UI reads the API base URL from `VITE_API_URL` at build time. Set this variable to the domain hosting the API endpoints (e.g. `https://api.example.com`).

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HubSpot Invoicing UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hubspot-invoicing-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "deploy": "npm run build && aws s3 sync dist/ $S3_BUCKET --delete"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import InvoiceList from './pages/InvoiceList';
+import Generate from './pages/Generate';
+
+export default function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Invoices</Link> |{' '}<Link to="/generate">Generate</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<InvoiceList />} />
+        <Route path="/generate" element={<Generate />} />
+      </Routes>
+    </Router>
+  );
+}

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/src/pages/Generate.jsx
+++ b/ui/src/pages/Generate.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+
+export default function Generate() {
+  const baseUrl = import.meta.env.VITE_API_URL || '';
+  const [form, setForm] = useState({
+    runType: 'full',
+    limit: '',
+    keepDraft: false,
+    ids: ''
+  });
+
+  const handleChange = e => {
+    const { name, value, type, checked } = e.target;
+    setForm(f => ({ ...f, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const payload = {
+      run_type: form.runType,
+      limit: form.limit ? Number(form.limit) : undefined,
+      keep_draft: form.keepDraft,
+      ids: form.ids ? form.ids.split(',').map(id => id.trim()) : undefined
+    };
+    fetch(`${baseUrl}/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(res => res.json())
+      .then(() => alert('Generation started'))
+      .catch(() => alert('Failed to generate'));
+  };
+
+  return (
+    <div>
+      <h1>Generate Invoices</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>
+            Run Type:
+            <select name="runType" value={form.runType} onChange={handleChange}>
+              <option value="full">Full</option>
+              <option value="pdf">PDF Only</option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Limit:
+            <input type="number" name="limit" value={form.limit} onChange={handleChange} />
+          </label>
+        </div>
+        <div>
+          <label>
+            Keep Draft:
+            <input type="checkbox" name="keepDraft" checked={form.keepDraft} onChange={handleChange} />
+          </label>
+        </div>
+        <div>
+          <label>
+            IDs (comma separated):
+            <input type="text" name="ids" value={form.ids} onChange={handleChange} />
+          </label>
+        </div>
+        <button type="submit">Run</button>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/pages/InvoiceList.jsx
+++ b/ui/src/pages/InvoiceList.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+
+export default function InvoiceList() {
+  const [invoices, setInvoices] = useState([]);
+  const baseUrl = import.meta.env.VITE_API_URL || '';
+
+  useEffect(() => {
+    fetch(`${baseUrl}/invoices`)
+      .then(res => res.json())
+      .then(setInvoices)
+      .catch(err => console.error('Failed to fetch invoices', err));
+  }, [baseUrl]);
+
+  return (
+    <div>
+      <h1>Invoice List</h1>
+      <ul>
+        {invoices.map(inv => (
+          <li key={inv.id}>
+            {inv.name}{' '}
+            <a href={`${baseUrl}/invoices/${inv.id}`} target="_blank" rel="noopener noreferrer">
+              View
+            </a>{' '}
+            <a
+              href={`${baseUrl}/invoices/${inv.id}/download`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- add lightweight React SPA under `ui/` with pages for listing invoices and triggering generation
- document build/deploy steps and API URL environment variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686057a4231c8327b704fa60382fc603