### PR TITLE
Improve deployment docs and packaging

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,6 +31,14 @@ echo "Step 2: Building lean package..."
 echo "--> Copying source files..."
 cp -r src/ "$PACKAGE_DIR/"
 cp package.json package-lock.json "$PACKAGE_DIR/"
+if [ -d handlers ]; then
+  echo "--> Copying additional handlers..."
+  cp -r handlers "$PACKAGE_DIR/"
+fi
+if [ -d ui ]; then
+  echo "--> Copying UI files..."
+  cp -r ui "$PACKAGE_DIR/"
+fi
 
 cd "$PACKAGE_DIR"
 

--- a/docs/API_INFRASTRUCTURE_GUIDE.md
+++ b/docs/API_INFRASTRUCTURE_GUIDE.md
@@ -1,0 +1,41 @@
+# API and Infrastructure Setup
+
+This guide describes the additional AWS resources required when exposing the
+invoice Lambda through an HTTP API and hosting the optional web UI.
+
+## 1. Lambda Functions
+
+- **HubSpotInvoicingProcessor** – main function that generates invoices.
+- **(Optional) HubSpotInvoicingUIHandler** – lightweight handler used by the UI
+  to trigger invoice generation.  This can simply proxy the event body to the
+  main processor.
+
+Package both handlers in `deploy.sh` by copying a `handlers/` directory if it
+exists.
+
+## 2. API Gateway
+
+1. Create a new **HTTP API**.
+2. Add a `POST /generate` route that invokes the `HubSpotInvoicingUIHandler` or
+   directly invokes `HubSpotInvoicingProcessor`.
+3. Enable CORS for `POST` requests from your UI domain.
+4. Deploy to a stage (e.g. `prod`) and note the invoke URL.
+
+## 3. S3 Static Web UI
+
+1. Build the UI with `npm run build`.
+2. Create an S3 bucket with static website hosting enabled.
+3. Upload the contents of the build directory.
+4. Optionally create a CloudFront distribution for HTTPS.
+5. Configure the UI to call the API Gateway URL from above.
+
+## 4. IAM Permissions
+
+Ensure the Lambda role has permission to write to CloudWatch, read your HubSpot
+secret from Secrets Manager, access S3 for PDF storage and reports, and if using
+Mailgun, allow outbound internet access via a NAT gateway or VPC endpoint.
+
+---
+
+After provisioning these resources, deploy the Lambda with `deploy.sh` and test
+the `/generate` endpoint using `curl` or the provided web UI.


### PR DESCRIPTION
## Summary
- document optional UI deployment and API gateway setup
- describe new event fields
- add example payloads
- include infrastructure guide
- package handlers/UI if present in deploy script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68606ae6f1148327b858500f3860899d